### PR TITLE
remove reports directory from psalm config

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -17,7 +17,6 @@
         <directory name="src" />
         <directory name="tests" />
         <ignoreFiles>
-            <directory name="reports" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>


### PR DESCRIPTION
This fixes a mistake from the base template (which also needs to be fixed).