### PR TITLE
streamline timers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           name: Mutation Tests
           command: |
             mv ~/reports/junit.xml reports/coverage-xml/junit.xml
-            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml
+            php -d memory_limit=-1 vendor/bin/infection --threads=4 --min-msi=100 --min-covered-msi=100 --coverage=reports/coverage-xml --skip-initial-tests
       - store_artifacts:
           path: reports/infection.html
           destination: infection.html

--- a/README.md
+++ b/README.md
@@ -62,17 +62,20 @@ for ($i = 0; $i < 3; $i++) {
 ## Testing with FixedTimer
 
 The usual timer in the code is `Timer` while the tests would use `FixedTimer`
-without changing the code. This is a benefit of using composition.
+without changing the code. Having `TimerInterface` is a benefit of using
+composition. Since both `Timer` and `FixedTimer` have similar functionality, the
+base functionalities are contained in `AbstractTimer` with overriding methods as
+necessary.
 
-A basic version of `FixedTimer` exists and has a `setDuration` method that
-allows for setting the duration (since no other properties need to exist). 
+`FixedTimer` uses two constant (fixed) values (instead of the time): One for
+start, and another for stop.
 
 ### Examples
 
 These are very simple examples of having a class that uses the timer as well as
 a class that uses the class and a class that tests the class. In real-world
 scenarios, use a [container](https://github.com/mts7/php-dependency-injection)
-for dependency injection.
+for dependency injection and a callable that takes time.
 
 ```php
 class Benchmark
@@ -109,14 +112,12 @@ class BenchmarkTest
 {
     public function testRun(): void
     {
-        $duration = 1;
         $timer = new \MtsTimer\FixedTimer();
-        $timer->configure($duration);
         $benchmark = new Benchmark($timer);
+
+        $duration = $benchmark->run([RunTheBenchmark::class, 'doNothing']);
         
-        $time = $timer->getDuration();
-        
-        $this->assertSame($duration, $time);
+        $this->assertSame($timer::DURATION, $duration);
     }
 }
 ```

--- a/build.xml
+++ b/build.xml
@@ -141,6 +141,7 @@
             <arg value="--min-msi=100" />
             <arg value="--min-covered-msi=100" />
             <arg value="--coverage=reports" />
+            <arg value="--skip-initial-tests" />
         </exec>
     </target>
 </project>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,6 +3,7 @@
          name="Code Standards"
          xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
     <file>src/</file>
+    <file>tests/</file>
 
     <config name="ignore_warnings_on_exit" value="1"/>
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -33,7 +33,7 @@
         </UnusedClass>
         <MissingThrowsDocblock>
             <errorLevel type="suppress">
-                <directory name="tests/Unit" />
+                <directory name="tests" />
             </errorLevel>
         </MissingThrowsDocblock>
     </issueHandlers>

--- a/src/AbstractTimer.php
+++ b/src/AbstractTimer.php
@@ -31,7 +31,12 @@ abstract class AbstractTimer implements TimerInterface
     {
         // save the time prior to executing additional statements
         $now = $this->getNow();
-        if ($this->timeStop > $this->timeStart || $this->timeStart === 0.0) {
+        if ($this->timeStop > $this->timeStart) {
+            throw new IncompleteTimingException(
+                'Call $timer->reset() or $timer->start() before calling $timer->stop() again.'
+            );
+        }
+        if ($this->timeStart === 0.0) {
             throw new IncompleteTimingException('Call $timer->start() prior to calling $timer->stop().');
         }
         $this->timeStop = $now;

--- a/src/AbstractTimer.php
+++ b/src/AbstractTimer.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MtsTimer;
+
+use MtsTimer\Exception\IncompleteTimingException;
+
+/**
+ * Base class for common timer logic
+ */
+abstract class AbstractTimer implements TimerInterface
+{
+    protected float $duration = 0.0;
+
+    protected float $timeStop = 0.0;
+
+    protected float $timeStart = 0.0;
+
+    public function reset(): void
+    {
+        $this->duration = 0.0;
+        $this->timeStart = 0.0;
+        $this->timeStop = 0.0;
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function stop(): void
+    {
+        // save the time prior to executing additional statements
+        $now = $this->getNow();
+        if ($this->timeStart === 0.0 || $this->timeStop > $this->timeStart) {
+            throw new IncompleteTimingException('Call $timer->start() prior to calling $timer->stop().');
+        }
+        $this->timeStop = $now;
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function getDuration(): float
+    {
+        if ($this->timeStart === 0.0) {
+            throw new IncompleteTimingException('Call $timer->start() before computing duration.');
+        }
+        if ($this->timeStop === 0.0) {
+            throw new IncompleteTimingException('Call $timer->stop() before computing duration.');
+        }
+
+        return $this->timeStop - $this->timeStart;
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function getTotalDuration(): float
+    {
+        if ($this->duration === 0.0) {
+            throw new IncompleteTimingException(
+                'Call $timer->sumDuration() after stopping the timer before getting the total duration.'
+            );
+        }
+
+        return $this->duration;
+    }
+
+    /**
+     * Adds the last duration to the existing duration value for a running total
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function addDuration(): void
+    {
+        $this->duration += $this->getDuration();
+    }
+
+    protected function getNow(): float
+    {
+        return microtime(true);
+    }
+
+    protected function setStart(float $time): void
+    {
+        $this->timeStart = $time;
+    }
+}

--- a/src/AbstractTimer.php
+++ b/src/AbstractTimer.php
@@ -31,7 +31,7 @@ abstract class AbstractTimer implements TimerInterface
     {
         // save the time prior to executing additional statements
         $now = $this->getNow();
-        if ($this->timeStart === 0.0 || $this->timeStop > $this->timeStart) {
+        if ($this->timeStop > $this->timeStart || $this->timeStart === 0.0) {
             throw new IncompleteTimingException('Call $timer->start() prior to calling $timer->stop().');
         }
         $this->timeStop = $now;

--- a/src/FixedTimer.php
+++ b/src/FixedTimer.php
@@ -7,38 +7,34 @@ namespace MtsTimer;
 /**
  * Use a timer with fixed values for testing classes implementing TimerInterface.
  */
-class FixedTimer implements TimerInterface
+class FixedTimer extends AbstractTimer
 {
-    private float $duration = 0.0;
+    public const DURATION = 1.7;
 
-    public function setDuration(float $duration): void
-    {
-        $this->duration = $duration;
-    }
-
-    public function reset(): void
-    {
-        // there is no need to reset since the values are pre-configured
-    }
-
+    /**
+     * Sets the start value to an arbitrary value to avoid getting the time.
+     */
     public function start(): void
     {
-        // the start value should be set by configure() method
+        // this allows multiple fixed calls to work
+        $this->timeStop = 0;
+
+        $this->setStart(1.0);
     }
 
-    public function stop(): void
+    /**
+     * Gets the sum of the start time and the fixed duration.
+     *
+     * The final calculation for stop will be start + duration - start, so the
+     * fixed duration set in setDuration() will be the result.
+     *
+     * @see start()
+     * @see stop()
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    protected function getNow(): float
     {
-        // the end value should be set by configure() method
-    }
-
-    public function getDuration(): float
-    {
-        // this is unused
-        return 0.0;
-    }
-
-    public function getTotalDuration(): float
-    {
-        return $this->duration;
+        return $this->timeStart + self::DURATION;
     }
 }

--- a/src/Timer.php
+++ b/src/Timer.php
@@ -4,72 +4,13 @@ declare(strict_types=1);
 
 namespace MtsTimer;
 
-use MtsTimer\Exception\IncompleteTimingException;
-
 /**
  * Timer for handling timing of events/processes.
  */
-final class Timer implements TimerInterface
+final class Timer extends AbstractTimer
 {
-    private float $duration = 0.0;
-
-    private float $timeStop = 0.0;
-
-    private float $timeStart = 0.0;
-
-    public function reset(): void
-    {
-        $this->duration = 0.0;
-        $this->timeStart = 0.0;
-        $this->timeStop = 0.0;
-    }
-
     public function start(): void
     {
-        $this->timeStop = 0.0;
-        $this->timeStart = microtime(true);
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function stop(): void
-    {
-        // save the time prior to executing additional statements
-        $now = microtime(true);
-        if ($this->timeStop !== 0.0) {
-            throw new IncompleteTimingException('Call $timer->start() prior to calling $timer->stop().');
-        }
-        $this->timeStop = $now;
-        $this->duration += $this->getDuration();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function getDuration(): float
-    {
-        if ($this->timeStart === 0.0) {
-            throw new IncompleteTimingException('Call $timer->start() before computing duration.');
-        }
-        if ($this->timeStop === 0.0) {
-            throw new IncompleteTimingException('Call $timer->stop() before computing duration.');
-        }
-
-        return $this->timeStop - $this->timeStart;
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function getTotalDuration(): float
-    {
-        if ($this->duration === 0.0) {
-            throw new IncompleteTimingException(
-                'Call $timer->start(); followed by $timer->stop(); before getting the total duration.'
-            );
-        }
-
-        return $this->duration;
+        $this->setStart($this->getNow());
     }
 }

--- a/src/TimerInterface.php
+++ b/src/TimerInterface.php
@@ -20,17 +20,30 @@ interface TimerInterface
     public function start(): void;
 
     /**
-     * Ends the timer.
+     * Stops the timer.
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
      */
     public function stop(): void;
 
     /**
      * Gets the duration of the last timer.
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
      */
     public function getDuration(): float;
 
     /**
      * Gets the total duration from all timers.
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
      */
     public function getTotalDuration(): float;
+
+    /**
+     * Adds the last duration to the existing duration value for a running total
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function addDuration(): void;
 }

--- a/tests/TimerTestTrait.php
+++ b/tests/TimerTestTrait.php
@@ -96,6 +96,17 @@ trait TimerTestTrait
     /**
      * @throws \MtsTimer\Exception\IncompleteTimingException
      */
+    public function testStop(): void
+    {
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage('Call $timer->start() prior to calling $timer->stop().');
+
+        $this->fixture->stop();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
     public function testStopDouble(): void
     {
         $this->initializeTimer();

--- a/tests/TimerTestTrait.php
+++ b/tests/TimerTestTrait.php
@@ -112,7 +112,7 @@ trait TimerTestTrait
         $this->initializeTimer();
 
         $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage('Call $timer->start() prior to calling $timer->stop().');
+        $this->expectErrorMessage('Call $timer->reset() or $timer->start() before calling $timer->stop() again.');
 
         $this->fixture->stop();
     }

--- a/tests/TimerTestTrait.php
+++ b/tests/TimerTestTrait.php
@@ -1,0 +1,171 @@
+<?php
+
+/** @noinspection PhpUnused */
+
+declare(strict_types=1);
+
+namespace MtsTimer\Tests;
+
+use MtsTimer\Exception\IncompleteTimingException;
+use MtsTimer\TimerInterface;
+
+/**
+ * Common methods for testing AbstractTimer
+ *
+ * This introduces planned redundancy since each implementor of AbstractTimer
+ * should include this trait, which then tests all the common methods within
+ * AbstractTimer. Each child TimerInterface class may test its own methods that
+ * differ from those in AbstractTimer. In general, all TimerInterface objects
+ * should have the same logic for timing.
+ */
+trait TimerTestTrait
+{
+    private TimerInterface $fixture;
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testResetDuration(): void
+    {
+        $this->initializeTimer();
+        $duration = $this->fixture->getDuration();
+
+        $this->fixture->reset();
+
+        $this->assertGreaterThan(0.0, $duration);
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage('Call $timer->start() before computing duration.');
+
+        $this->fixture->getDuration();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testResetTotalDuration(): void
+    {
+        $this->initializeTimer();
+        $duration = $this->fixture->getDuration();
+
+        $this->fixture->reset();
+
+        $this->assertGreaterThan(0.0, $duration);
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage(
+            'Call $timer->sumDuration() after stopping the timer before getting the total duration.'
+        );
+
+        $this->fixture->getTotalDuration();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testResetStop(): void
+    {
+        $this->initializeTimer();
+        $duration = $this->fixture->getDuration();
+
+        $this->fixture->reset();
+
+        $this->assertGreaterThan(0.0, $duration);
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage('Call $timer->start() prior to calling $timer->stop().');
+
+        $this->fixture->stop();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testStart(): void
+    {
+        $this->initializeTimer();
+        $duration = $this->fixture->getDuration();
+        $this->fixture->reset();
+
+        $this->fixture->start();
+
+        $this->assertGreaterThan(0.0, $duration);
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage('Call $timer->stop() before computing duration.');
+
+        $this->fixture->getDuration();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testStopDouble(): void
+    {
+        $this->initializeTimer();
+
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage('Call $timer->start() prior to calling $timer->stop().');
+
+        $this->fixture->stop();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testStopResult(): void
+    {
+        $this->initializeTimer();
+
+        $duration = $this->fixture->getDuration();
+        $total = $this->fixture->getTotalDuration();
+
+        $this->assertSame($duration, $total);
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testGetTotalDuration(): void
+    {
+        $this->expectException(IncompleteTimingException::class);
+        $this->expectErrorMessage(
+            'Call $timer->sumDuration() after stopping the timer before getting the total duration.'
+        );
+
+        $this->fixture->getTotalDuration();
+    }
+
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testGetTotalDurationMultiple(): void
+    {
+        $duration = 0;
+        $this->initializeTimer();
+        $duration += $this->fixture->getDuration();
+        $this->initializeTimer();
+        $duration += $this->fixture->getDuration();
+        $this->initializeTimer();
+        $duration += $this->fixture->getDuration();
+
+        $this->assertSame($duration, $this->fixture->getTotalDuration());
+        $this->assertLessThan(microtime(true), $duration);
+    }
+
+    private function doStuff(): void
+    {
+        $array = array_fill(0, 100, 'apple');
+        $copy = array_reverse($array);
+        sort($copy);
+    }
+
+    /**
+     * Calls both start and stop to initialize those values.
+     *
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    protected function initializeTimer(): void
+    {
+        $this->fixture->start();
+        $this->doStuff();
+        $this->fixture->stop();
+        $this->fixture->addDuration();
+    }
+}

--- a/tests/Unit/FixedTimerTest.php
+++ b/tests/Unit/FixedTimerTest.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace MtsTimer\Tests\Unit;
 
 use MtsTimer\FixedTimer;
+use MtsTimer\Tests\TimerTestTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * This tests all of the base functionality using FixedTimer.
+ *
  * @group timer
  */
 final class FixedTimerTest extends TestCase
 {
-    private FixedTimer $fixture;
+    use TimerTestTrait;
 
     protected function setUp(): void
     {
@@ -21,27 +24,17 @@ final class FixedTimerTest extends TestCase
         $this->fixture = new FixedTimer();
     }
 
-    public function testSetDuration(): void
+    /**
+     * @throws \MtsTimer\Exception\IncompleteTimingException
+     */
+    public function testGetDurationFixed(): void
     {
-        $duration = 1.7;
+        $this->initializeTimer();
 
-        $this->fixture->setDuration($duration);
+        $duration = $this->fixture->getDuration();
         $total = $this->fixture->getTotalDuration();
 
-        $this->assertSame($duration, $total);
-    }
-
-    public function testSetDurationEmpty(): void
-    {
-        $duration = $this->fixture->getTotalDuration();
-
-        $this->assertSame(0.0, $duration);
-    }
-
-    public function testGetDuration(): void
-    {
-        $duration = $this->fixture->getDuration();
-
-        $this->assertSame(0.0, $duration);
+        $this->assertSame(FixedTimer::DURATION, round($duration, 1));
+        $this->assertSame(FixedTimer::DURATION, round($total, 1));
     }
 }

--- a/tests/Unit/TimerTest.php
+++ b/tests/Unit/TimerTest.php
@@ -4,157 +4,23 @@ declare(strict_types=1);
 
 namespace MtsTimer\Tests\Unit;
 
-use MtsTimer\Exception\IncompleteTimingException;
+use MtsTimer\Tests\TimerTestTrait;
 use MtsTimer\Timer;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * This tests all the base functionality using Timer.
+ *
  * @group timer
  */
 final class TimerTest extends TestCase
 {
-    private Timer $fixture;
+    use TimerTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->fixture = new Timer();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testResetDuration(): void
-    {
-        $this->initializeTimer();
-        $duration = $this->fixture->getDuration();
-
-        $this->fixture->reset();
-
-        $this->assertGreaterThan(0.0, $duration);
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage('Call $timer->start() before computing duration.');
-        $this->fixture->getDuration();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testResetTotalDuration(): void
-    {
-        $this->initializeTimer();
-        $duration = $this->fixture->getDuration();
-
-        $this->fixture->reset();
-
-        $this->assertGreaterThan(0.0, $duration);
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage(
-            'Call $timer->start(); followed by $timer->stop(); before getting the total duration.'
-        );
-        $this->fixture->getTotalDuration();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testResetStop(): void
-    {
-        $this->initializeTimer();
-        $duration = $this->fixture->getDuration();
-
-        $this->fixture->reset();
-
-        $this->assertGreaterThan(0.0, $duration);
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage('Call $timer->start() before computing duration.');
-        $this->fixture->stop();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testStart(): void
-    {
-        $this->initializeTimer();
-        $duration = $this->fixture->getDuration();
-
-        $this->fixture->start();
-
-        $this->assertGreaterThan(0.0, $duration);
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage('Call $timer->stop() before computing duration.');
-        $this->fixture->getDuration();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testStopDouble(): void
-    {
-        $this->initializeTimer();
-
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage('Call $timer->start() prior to calling $timer->stop().');
-        $this->fixture->stop();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testStopResult(): void
-    {
-        $this->initializeTimer();
-
-        $duration = $this->fixture->getDuration();
-        $total = $this->fixture->getTotalDuration();
-
-        $this->assertSame($duration, $total);
-    }
-
-    public function testGetTotalDuration(): void
-    {
-        $this->expectException(IncompleteTimingException::class);
-        $this->expectErrorMessage(
-            'Call $timer->start(); followed by $timer->stop(); before getting the total duration.'
-        );
-        $this->fixture->getTotalDuration();
-    }
-
-    /**
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    public function testGetTotalDurationMultiple(): void
-    {
-        $duration = 0;
-        $this->initializeTimer();
-        $duration += $this->fixture->getDuration();
-        $this->initializeTimer();
-        $duration += $this->fixture->getDuration();
-        $this->initializeTimer();
-        $duration += $this->fixture->getDuration();
-
-        $this->assertSame($duration, $this->fixture->getTotalDuration());
-        $this->assertLessThan(microtime(true), $duration);
-    }
-
-    private function doStuff(): void
-    {
-        $array = array_fill(0, 100, 'apple');
-        $copy = array_reverse($array);
-        sort($copy);
-    }
-
-    /**
-     * Calls both start and stop to initialize those values.
-     *
-     * @throws \MtsTimer\Exception\IncompleteTimingException
-     */
-    private function initializeTimer(): void
-    {
-        $this->fixture->start();
-        $this->doStuff();
-        $this->fixture->stop();
     }
 }


### PR DESCRIPTION
* consolidate common methods to AbstractTimer
* consolidate common test methods to TimerTestTrait
* replace FixedTimer getDuration with DURATION
* adjust README to match current code changes
* adjust logic and tests to make more sense
* move double stop condition to its own validation
* expand psalm to check all files in tests/
* expand phpcs to check tests/
* change infection to skip initial tests